### PR TITLE
update the sdk to refresh user oauth tokens

### DIFF
--- a/FanMaker/build.gradle
+++ b/FanMaker/build.gradle
@@ -77,7 +77,7 @@ def githubProperties = new Properties()
 githubProperties.load(new FileInputStream(rootProject.file("github.properties")))
 
 def getVersionName = { ->
-    return "3.2.0"
+    return "4.0.0"
 }
 
 def getArtifactId = { ->

--- a/FanMaker/src/main/java/com/fanmaker/sdk/FanMakerSDKHttp.kt
+++ b/FanMaker/src/main/java/com/fanmaker/sdk/FanMakerSDKHttp.kt
@@ -16,25 +16,30 @@ class FanMakerSDKHttp(
     val queue = Volley.newRequestQueue(context)
 
     fun get(path: String, onSuccess: (JSONObject) -> Unit, onError: (Int, String) -> Unit) {
-        val request = FanMakerSDKHttpRequest(fanMakerSDK, Method.GET, path, null, token,
-            { response ->
-                val status = response.getInt("status")
-                if (status == 200) {
-                    onSuccess(response)
-                } else {
-                    val message = response.getString("message")
-                    onError(status, message)
-                }
+        resolveTokenAndExecute(
+            onReady = { tokenType ->
+                val request = FanMakerSDKHttpRequest(fanMakerSDK, Method.GET, path, null, token, tokenType,
+                    { response ->
+                        val status = response.getInt("status")
+                        if (status == 200) {
+                            onSuccess(response)
+                        } else {
+                            val message = response.getString("message")
+                            onError(status, message)
+                        }
+                    },
+                    { error ->
+                        try {
+                            onError(error.networkResponse.statusCode, error.message.toString())
+                        } catch (err: java.lang.Exception) {
+                            Log.e(TAG, err.localizedMessage)
+                        }
+                    }
+                )
+                queue.add(request)
             },
-            { error ->
-                try {
-                    onError(error.networkResponse.statusCode, error.message.toString())
-                } catch (err: java.lang.Exception) {
-                    Log.e(TAG, err.localizedMessage)
-                }
-            }
+            onError = onError
         )
-        queue.add(request)
     }
 
     fun post(
@@ -43,34 +48,69 @@ class FanMakerSDKHttp(
         onSuccess: (JSONObject) -> Unit,
         onError: (Int, String) -> Unit
     ) {
-
         val body = JSONObject(params)
-        val request = object: FanMakerSDKHttpRequest(fanMakerSDK, Method.POST, path, body, token,
-            { response ->
-                val status = response.getInt("status")
-                if (status >= 200  && status < 300) {
-                    onSuccess(response)
-                } else {
-                    onError(status, response.getString("message").toString())
-                }
-            },
-            { error ->
-                if (error.networkResponse == null) {
-                    onError(0, "Server not found or no Internet connection available")
-                } else {
-                    try {
-                        onError(error.networkResponse.statusCode, error.message.toString())
-                    } catch (err: java.lang.Exception) {
-                        Log.e(TAG, err.localizedMessage)
+        resolveTokenAndExecute(
+            onReady = { tokenType ->
+                val request = object: FanMakerSDKHttpRequest(fanMakerSDK, Method.POST, path, body, token, tokenType,
+                    { response ->
+                        val status = response.getInt("status")
+                        if (status >= 200  && status < 300) {
+                            onSuccess(response)
+                        } else {
+                            onError(status, response.getString("message").toString())
+                        }
+                    },
+                    { error ->
+                        if (error.networkResponse == null) {
+                            onError(0, "Server not found or no Internet connection available")
+                        } else {
+                            try {
+                                onError(error.networkResponse.statusCode, error.message.toString())
+                            } catch (err: java.lang.Exception) {
+                                Log.e(TAG, err.localizedMessage)
+                            }
+                        }
+                    }
+                ) {
+                    override fun getFanMakerToken(): String {
+                        return super.getFanMakerToken()
                     }
                 }
-            }
-        ) {
-            override fun getFanMakerToken(): String {
-                return super.getFanMakerToken()
-            }
+                queue.add(request)
+            },
+            onError = onError
+        )
+    }
+
+    /**
+     * Resolves the token type (API vs OAuth) before executing the request.
+     * If the token is an expired OAuth token, this will refresh it first (coalesced
+     * with other concurrent refresh requests) and persist the new token.
+     *
+     * @param onReady Called with the resolved [FanMakerSDKTokenType] (or null for legacy behavior)
+     * @param onError Called if token refresh fails
+     */
+    private fun resolveTokenAndExecute(
+        onReady: (FanMakerSDKTokenType?) -> Unit,
+        onError: (Int, String) -> Unit
+    ) {
+        if (token != null && token.isNotEmpty()) {
+            FanMakerSDKTokenResolver.getValidToken(
+                tokenString = token,
+                apiBase = FanMakerSDKHttpRequest.API_BASE,
+                onRefreshed = { newTokenString ->
+                    // Persist the refreshed token back to SharedPreferences
+                    fanMakerSDK.updateSessionToken(newTokenString)
+                },
+                onSuccess = { tokenType ->
+                    onReady(tokenType)
+                },
+                onError = onError
+            )
+        } else {
+            // No token provided, use legacy behavior
+            onReady(null)
         }
-        queue.add(request)
     }
 
     companion object {

--- a/FanMaker/src/main/java/com/fanmaker/sdk/FanMakerSDKToken.kt
+++ b/FanMaker/src/main/java/com/fanmaker/sdk/FanMakerSDKToken.kt
@@ -1,0 +1,350 @@
+package com.fanmaker.sdk
+
+import android.util.Log
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+// MARK: - OAuth Token Data Model
+
+/**
+ * Represents the parsed JSON payload of an OAuth access token from Doorkeeper.
+ * `expires_at` is optional because standard Doorkeeper responses don't always include it;
+ * when missing it is computed from `created_at + expires_in`.
+ */
+data class FanMakerSDKOAuthToken(
+    val access_token: String,
+    val refresh_token: String,
+    val expires_in: Int,
+    val created_at: Int,
+    private val _expires_at: Int? = null
+) {
+    /** Unix timestamp when the access token expires. Computed if not provided. */
+    val expires_at: Int
+        get() = _expires_at ?: (created_at + expires_in)
+
+    /**
+     * Returns a JSON string representation suitable for storing back in SharedPreferences
+     * or sending as a header value. Always includes `expires_at` (computed if needed).
+     */
+    fun toJSONString(): String? {
+        return try {
+            val json = JSONObject()
+            json.put("access_token", access_token)
+            json.put("refresh_token", refresh_token)
+            json.put("expires_in", expires_in)
+            json.put("expires_at", expires_at)
+            json.put("created_at", created_at)
+            json.toString()
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    companion object {
+        /**
+         * Attempts to parse a JSON string into an [FanMakerSDKOAuthToken].
+         * Returns null if the string is not valid OAuth token JSON.
+         */
+        fun fromJSON(jsonString: String): FanMakerSDKOAuthToken? {
+            return try {
+                val json = JSONObject(jsonString)
+                // All required fields must be present
+                if (!json.has("access_token") || !json.has("refresh_token") ||
+                    !json.has("expires_in") || !json.has("created_at")) {
+                    return null
+                }
+                FanMakerSDKOAuthToken(
+                    access_token = json.getString("access_token"),
+                    refresh_token = json.getString("refresh_token"),
+                    expires_in = json.getInt("expires_in"),
+                    created_at = json.getInt("created_at"),
+                    _expires_at = if (json.has("expires_at") && !json.isNull("expires_at"))
+                        json.getInt("expires_at") else null
+                )
+            } catch (e: Exception) {
+                null
+            }
+        }
+    }
+}
+
+// MARK: - Token Type
+
+/**
+ * Represents the two possible token types the SDK may encounter.
+ */
+sealed class FanMakerSDKTokenType {
+    /** A plain API token string (e.g., "a8df7897dfaiod7faehrl") */
+    data class ApiToken(val token: String) : FanMakerSDKTokenType()
+    /** An OAuth token parsed from a JSON string */
+    data class OAuthToken(val oauthToken: FanMakerSDKOAuthToken) : FanMakerSDKTokenType()
+}
+
+// MARK: - Token Resolver
+
+/**
+ * Utility for detecting token types, checking expiration, building header values,
+ * and refreshing expired OAuth tokens via Doorkeeper.
+ *
+ * Refresh requests are coalesced: if multiple callers request a refresh at the same time,
+ * only one network request is made and the result is shared with all waiting callers.
+ */
+object FanMakerSDKTokenResolver {
+    private const val TAG = "FanMakerSDKToken"
+
+    /**
+     * Buffer in seconds before `expires_at` to consider the token expired,
+     * avoiding edge-case races where the token expires mid-flight.
+     */
+    private const val EXPIRATION_BUFFER_SECONDS = 30
+
+    // MARK: - Refresh Coalescing State
+
+    /** Lock protecting the refresh queue state. */
+    private val refreshLock = ReentrantLock()
+    /** Whether a refresh network request is currently in-flight. */
+    private var isRefreshing = false
+    /** Queued completions waiting for the in-flight refresh to finish. */
+    private val pendingRefreshCompletions = mutableListOf<(Result<FanMakerSDKOAuthToken>) -> Unit>()
+
+    // MARK: - Token Type Detection
+
+    /**
+     * Attempts to parse the token string as an OAuth JSON payload.
+     * Falls back to [FanMakerSDKTokenType.ApiToken] if JSON decoding fails.
+     */
+    fun resolve(tokenString: String): FanMakerSDKTokenType {
+        val oauthToken = FanMakerSDKOAuthToken.fromJSON(tokenString)
+        return if (oauthToken != null) {
+            FanMakerSDKTokenType.OAuthToken(oauthToken)
+        } else {
+            FanMakerSDKTokenType.ApiToken(tokenString)
+        }
+    }
+
+    // MARK: - Expiration Check
+
+    /**
+     * Returns `true` if the OAuth token has expired (or will expire within the buffer window).
+     */
+    fun isExpired(token: FanMakerSDKOAuthToken): Boolean {
+        val nowSeconds = System.currentTimeMillis() / 1000
+        return nowSeconds >= (token.expires_at - EXPIRATION_BUFFER_SECONDS)
+    }
+
+    // MARK: - Header Value Builders
+
+    /**
+     * Returns the value for the `Authorization` header.
+     * - For OAuth tokens: `"Bearer <access_token>"`
+     * - For API tokens: the raw token string as-is
+     */
+    fun authorizationHeaderValue(tokenType: FanMakerSDKTokenType): String {
+        return when (tokenType) {
+            is FanMakerSDKTokenType.ApiToken -> tokenType.token
+            is FanMakerSDKTokenType.OAuthToken -> {
+                val accessToken = tokenType.oauthToken.access_token
+                if (accessToken.lowercase().startsWith("bearer ")) {
+                    accessToken
+                } else {
+                    "Bearer $accessToken"
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the value for the `X-FanMaker-SessionToken` header.
+     * - For OAuth tokens: the full JSON string (re-encoded to include refreshed data)
+     * - For API tokens: the raw token string as-is
+     */
+    fun sessionTokenHeaderValue(tokenType: FanMakerSDKTokenType, rawTokenString: String): String {
+        return when (tokenType) {
+            is FanMakerSDKTokenType.ApiToken -> tokenType.token
+            is FanMakerSDKTokenType.OAuthToken -> {
+                // Prefer re-encoding the token to ensure consistency after a refresh,
+                // but fall back to the raw string if encoding fails.
+                tokenType.oauthToken.toJSONString() ?: rawTokenString
+            }
+        }
+    }
+
+    // MARK: - High-Level Token Resolution
+
+    /**
+     * Resolves the token type, checks expiration for OAuth tokens, refreshes if needed,
+     * and returns a valid token type ready to use for headers.
+     *
+     * @param tokenString The raw token string from SharedPreferences
+     * @param apiBase The base URL for the API (e.g., "https://api3.fanmaker.com")
+     * @param onRefreshed Called with the new JSON string when a token is refreshed,
+     *                    so the caller can persist it back to storage
+     * @param onSuccess Called with the valid token type
+     * @param onError Called with error code and message if refresh fails
+     */
+    fun getValidToken(
+        tokenString: String,
+        apiBase: String,
+        onRefreshed: (String) -> Unit,
+        onSuccess: (FanMakerSDKTokenType) -> Unit,
+        onError: (Int, String) -> Unit
+    ) {
+        val tokenType = resolve(tokenString)
+
+        when (tokenType) {
+            is FanMakerSDKTokenType.ApiToken -> onSuccess(tokenType)
+
+            is FanMakerSDKTokenType.OAuthToken -> {
+                if (!isExpired(tokenType.oauthToken)) {
+                    onSuccess(tokenType)
+                } else {
+                    Log.w(TAG, "OAuth token expired, initiating refresh...")
+                    // Token is expired -- enqueue refresh (coalesced with other callers)
+                    enqueueRefresh(tokenType.oauthToken, apiBase) { result ->
+                        result.fold(
+                            onSuccess = { newToken ->
+                                // Notify caller so they can persist the new token
+                                newToken.toJSONString()?.let { onRefreshed(it) }
+                                onSuccess(FanMakerSDKTokenType.OAuthToken(newToken))
+                            },
+                            onFailure = { error ->
+                                onError(0, error.message ?: "Token refresh failed")
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Token Refresh (Coalesced)
+
+    /**
+     * Enqueues a refresh request. If a refresh is already in-flight, the completion
+     * is queued and will be called with the result of the in-flight request.
+     * Only one network request is made regardless of how many callers need a refresh.
+     */
+    private fun enqueueRefresh(
+        token: FanMakerSDKOAuthToken,
+        apiBase: String,
+        completion: (Result<FanMakerSDKOAuthToken>) -> Unit
+    ) {
+        refreshLock.withLock {
+            if (isRefreshing) {
+                // A refresh is already in-flight -- just queue up and wait
+                val queueSize = pendingRefreshCompletions.size + 1
+                Log.d(TAG, "Refresh already in-flight, queuing caller ($queueSize waiting)")
+                pendingRefreshCompletions.add(completion)
+                return
+            }
+            // We're the first -- mark as refreshing
+            isRefreshing = true
+        }
+
+        executeRefresh(token, apiBase) { result ->
+            // Grab all pending completions and reset state
+            val waitingCompletions: List<(Result<FanMakerSDKOAuthToken>) -> Unit>
+            refreshLock.withLock {
+                waitingCompletions = pendingRefreshCompletions.toList()
+                pendingRefreshCompletions.clear()
+                isRefreshing = false
+            }
+
+            val totalCallers = waitingCompletions.size + 1
+            Log.d(TAG, "Refresh complete, notifying $totalCallers caller(s)")
+
+            // Notify the original caller
+            completion(result)
+            // Notify all queued callers with the same result
+            for (waiting in waitingCompletions) {
+                waiting(result)
+            }
+        }
+    }
+
+    /**
+     * Executes the actual network request to refresh the OAuth token via Doorkeeper.
+     * Only called by [enqueueRefresh] -- never directly.
+     *
+     * POST /oauth/token
+     * Body: { "grant_type": "refresh_token", "refresh_token": "<refresh_token>" }
+     */
+    private fun executeRefresh(
+        token: FanMakerSDKOAuthToken,
+        apiBase: String,
+        completion: (Result<FanMakerSDKOAuthToken>) -> Unit
+    ) {
+        Thread {
+            try {
+                val urlString = "$apiBase/oauth/token"
+                Log.d(TAG, "Refreshing OAuth token...")
+
+                val url = URL(urlString)
+                val connection = url.openConnection() as HttpURLConnection
+                connection.requestMethod = "POST"
+                connection.setRequestProperty("Content-Type", "application/json")
+                connection.setRequestProperty("Accept", "application/json")
+                connection.doOutput = true
+                connection.connectTimeout = 15000
+                connection.readTimeout = 15000
+
+                val body = JSONObject()
+                body.put("grant_type", "refresh_token")
+                body.put("refresh_token", token.refresh_token)
+
+                OutputStreamWriter(connection.outputStream).use { writer ->
+                    writer.write(body.toString())
+                    writer.flush()
+                }
+
+                val responseCode = connection.responseCode
+                Log.d(TAG, "Refresh response HTTP $responseCode")
+
+                if (responseCode == 200) {
+                    val reader = BufferedReader(InputStreamReader(connection.inputStream))
+                    val responseBody = reader.readText()
+                    reader.close()
+
+                    val newToken = FanMakerSDKOAuthToken.fromJSON(responseBody)
+                    if (newToken != null) {
+                        Log.w(TAG, "OAuth token refreshed successfully")
+                        completion(Result.success(newToken))
+                    } else {
+                        Log.e(TAG, "OAuth token refresh failed: could not parse response")
+                        completion(Result.failure(Exception("Failed to decode refreshed token")))
+                    }
+                } else {
+                    val errorStream = connection.errorStream ?: connection.inputStream
+                    val errorReader = BufferedReader(InputStreamReader(errorStream))
+                    val errorBody = errorReader.readText()
+                    errorReader.close()
+
+                    var errorMessage = "Token refresh failed with HTTP $responseCode"
+                    try {
+                        val errorJson = JSONObject(errorBody)
+                        if (errorJson.has("error")) {
+                            errorMessage += ": ${errorJson.getString("error")}"
+                            if (errorJson.has("error_description")) {
+                                errorMessage += " - ${errorJson.getString("error_description")}"
+                            }
+                        }
+                    } catch (_: Exception) { }
+
+                    Log.e(TAG, "OAuth token refresh failed: $errorMessage")
+                    completion(Result.failure(Exception(errorMessage)))
+                }
+
+                connection.disconnect()
+            } catch (e: Exception) {
+                Log.e(TAG, "OAuth token refresh failed (network): ${e.localizedMessage}")
+                completion(Result.failure(Exception("Token refresh network error: ${e.localizedMessage}")))
+            }
+        }.start()
+    }
+}

--- a/FanMaker/src/main/java/com/fanmaker/sdk/FanMakerSDKWebView.kt
+++ b/FanMaker/src/main/java/com/fanmaker/sdk/FanMakerSDKWebView.kt
@@ -42,19 +42,14 @@ import kotlinx.serialization.json.Json
 import com.fanmaker.sdk.FanMakerSDKs
 
 import android.graphics.Bitmap
+import android.widget.FrameLayout
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
-import android.widget.ImageView
-import android.graphics.drawable.AnimationDrawable
-import android.widget.FrameLayout
-
 class FanMakerSDKWebView : AppCompatActivity() {
     private lateinit var fanMakerSDK: FanMakerSDK
     private lateinit var fanMakerSharedPreferences: FanMakerSharedPreferences
-    lateinit var animationDrawable: AnimationDrawable
-    lateinit var loadingAnimationFrame: FrameLayout
-    lateinit var loadingAnimationView: ImageView
+    private lateinit var loadingFrame: FrameLayout
 
     // Temporary URI for camera photo
     private var cameraPhotoUri: Uri? = null
@@ -195,23 +190,17 @@ class FanMakerSDKWebView : AppCompatActivity() {
         //     WebView.setWebContentsDebuggingEnabled(true)
         // }
 
-        if(fanMakerSDK.useDarkLoadingScreen) {
-            loadingAnimationFrame = findViewById<FrameLayout>(R.id.fanmaker_sdk_dark_loading_frame)
-            loadingAnimationView = findViewById<ImageView>(R.id.darkLoadingGif)
+        loadingFrame = if (fanMakerSDK.useDarkLoadingScreen) {
+            findViewById(R.id.fanmaker_sdk_dark_loading_frame)
         } else {
-            loadingAnimationFrame = findViewById<FrameLayout>(R.id.fanmaker_sdk_light_loading_frame)
-            loadingAnimationView = findViewById<ImageView>(R.id.lightLoadingGif)
+            findViewById(R.id.fanmaker_sdk_light_loading_frame)
         }
-
-        loadingAnimationFrame.visibility = FrameLayout.VISIBLE
-        animationDrawable = loadingAnimationView.drawable as AnimationDrawable
-        animationDrawable.start()
+        loadingFrame.visibility = FrameLayout.VISIBLE
 
         webView.webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 super.onPageFinished(view, url)
-                loadingAnimationFrame.visibility = FrameLayout.GONE
-                animationDrawable.stop()
+                loadingFrame.visibility = FrameLayout.GONE
             }
 
             override fun onReceivedError(view: WebView?, request: WebResourceRequest?, error: WebResourceError?) {

--- a/FanMaker/src/main/java/com/fanmaker/sdk/FanMakerSDKWebViewFragment.kt
+++ b/FanMaker/src/main/java/com/fanmaker/sdk/FanMakerSDKWebViewFragment.kt
@@ -50,11 +50,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-import android.widget.ImageView
-import android.graphics.drawable.AnimationDrawable
-import android.widget.FrameLayout
 
 import android.graphics.Bitmap
+import android.widget.FrameLayout
 import java.io.ByteArrayOutputStream
 import java.io.FileOutputStream
 
@@ -66,10 +64,7 @@ class FanMakerSDKWebViewFragment : Fragment() {
     private lateinit var imagePickerLauncher: androidx.activity.result.ActivityResultLauncher<androidx.activity.result.PickVisualMediaRequest>
     private lateinit var fanMakerSDK: FanMakerSDK
     private lateinit var fanMakerSharedPreferences: FanMakerSharedPreferences
-    lateinit var animationDrawable: AnimationDrawable
-    lateinit var loadingAnimationFrame: FrameLayout
-    lateinit var loadingAnimationView: ImageView
-
+    private lateinit var loadingFrame: FrameLayout
     private var _viewBinding: FanmakerSdkWebviewFragmentBinding? = null
     private val viewBinding get() = _viewBinding!!
 
@@ -180,23 +175,17 @@ class FanMakerSDKWebViewFragment : Fragment() {
             return viewBinding.root
         }
 
-        if(fanMakerSDK!!.useDarkLoadingScreen) {
-            loadingAnimationFrame = viewBinding.root.findViewById<FrameLayout>(R.id.fanmaker_sdk_dark_loading_frame)
-            loadingAnimationView = viewBinding.root.findViewById<ImageView>(R.id.darkLoadingGif)
+        loadingFrame = if (fanMakerSDK!!.useDarkLoadingScreen) {
+            viewBinding.root.findViewById(R.id.fanmaker_sdk_dark_loading_frame)
         } else {
-            loadingAnimationFrame = viewBinding.root.findViewById<FrameLayout>(R.id.fanmaker_sdk_light_loading_frame)
-            loadingAnimationView = viewBinding.root.findViewById<ImageView>(R.id.lightLoadingGif)
+            viewBinding.root.findViewById(R.id.fanmaker_sdk_light_loading_frame)
         }
-
-        loadingAnimationFrame.visibility = FrameLayout.VISIBLE
-        animationDrawable = loadingAnimationView.drawable as AnimationDrawable
-        animationDrawable.start()
+        loadingFrame.visibility = FrameLayout.VISIBLE
 
         webView.webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 super.onPageFinished(view, url)
-                loadingAnimationFrame.visibility = FrameLayout.GONE
-                animationDrawable.stop()
+                loadingFrame.visibility = FrameLayout.GONE
             }
         }
 

--- a/FanMaker/src/main/res/layout/fanmaker_sdk_webview.xml
+++ b/FanMaker/src/main/res/layout/fanmaker_sdk_webview.xml
@@ -19,48 +19,18 @@
     </WebView>
 
     <FrameLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/fanmaker_sdk_light_loading_frame"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/fanMakerLightLoading"
-        android:visibility="gone"
-        >
-
-        <ImageView
-            android:id="@+id/lightLoadingGif"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:visibility="visible"
-            android:src="@drawable/fanmaker_sdk_light_loading"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-    </FrameLayout>
+        android:visibility="gone" />
 
     <FrameLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:visibility="gone"
         android:id="@+id/fanmaker_sdk_dark_loading_frame"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/fanMakerDarkLoading"
-        >
-
-        <ImageView
-            android:id="@+id/darkLoadingGif"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:visibility="visible"
-            android:src="@drawable/fanmaker_sdk_dark_loading"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-    </FrameLayout>
+        android:visibility="gone" />
 
     <androidx.camera.view.PreviewView
         android:id="@+id/viewFinder"

--- a/FanMaker/src/main/res/layout/fanmaker_sdk_webview_fragment.xml
+++ b/FanMaker/src/main/res/layout/fanmaker_sdk_webview_fragment.xml
@@ -13,41 +13,18 @@
         android:layout_height="match_parent" />
 
     <FrameLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/fanmaker_sdk_light_loading_frame"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/fanMakerLightLoading"
-        android:visibility="gone"
-        >
-
-        <ImageView
-            android:id="@+id/lightLoadingGif"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:visibility="visible"
-            android:src="@drawable/fanmaker_sdk_light_loading" />
-    </FrameLayout>
+        android:visibility="gone" />
 
     <FrameLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:visibility="gone"
         android:id="@+id/fanmaker_sdk_dark_loading_frame"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/fanMakerDarkLoading"
-        >
-
-        <ImageView
-            android:id="@+id/darkLoadingGif"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:visibility="visible"
-            android:src="@drawable/fanmaker_sdk_dark_loading" />
-
-    </FrameLayout>
+        android:visibility="gone" />
 
     <androidx.camera.view.PreviewView
         android:id="@+id/viewFinder"

--- a/FanMaker/src/main/res/values/colors.xml
+++ b/FanMaker/src/main/res/values/colors.xml
@@ -22,5 +22,5 @@
     <color name="icFocused">#DDFFFFFF</color>
     <color name="icPressed">#AAFFFFFF</color>
     <color name="fanMakerLightLoading">#FFFFFF</color>
-    <color name="fanMakerDarkLoading">#1B1B1B</color>
+    <color name="fanMakerDarkLoading">#111111</color>
 </resources>

--- a/README.md
+++ b/README.md
@@ -302,9 +302,9 @@ fanMakerSDK1?.onActionTriggered = { action, params ->
 ```
 
 ### Loading Animation | Light vs Dark
-By default the FanMaker SDK will use a Light loading animated view when initializing the FanMaker SDK. There is an optional Dark loading animated view that you can use instead:
+By default the FanMaker SDK will use a Dark loading animated view when initializing the FanMaker SDK. If you prefer a Light loading animated view, you can set:
 ```
-fanMakerSDK1!!.useDarkLoadingScreen = true
+fanMakerSDK1!!.useDarkLoadingScreen = false
 ```
 
 ### Deep Linking / Universal Links

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.android.volley:volley:1.2.1'
     // implementation project(':FanMaker')
-    implementation 'com.fanmaker.sdk:fanmaker:3.2.0'
+    implementation 'com.fanmaker.sdk:fanmaker:4.0.0'
 
     // Updated test dependencies
     testImplementation 'junit:junit:4.13.2'

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -12,6 +12,7 @@
         <domain includeSubdomains="true">amazonaws.com</domain>
         <domain includeSubdomains="true">api3.fanmaker.work</domain>
         <domain includeSubdomains="true">api.fanmaker.work</domain>
+        <domain includeSubdomains="true">nux.fanmaker.work</domain>
         <domain includeSubdomains="true">rewards-hud.work</domain>
         <domain includeSubdomains="true">localhost</domain>
         <domain includeSubdomains="true">10.0.2.2</domain>

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+org.gradle.java.home=/Library/Java/JavaVirtualMachines/openjdk-17.jdk/Contents/Home
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
This pull request introduces significant improvements to the FanMaker SDK's authentication and token handling, along with some version and theme updates. The main focus is on robust support for OAuth token refresh, correct header management, and improved request handling. Below are the most important changes grouped by theme:

Authentication & Token Handling:

* Added OAuth token refresh support: HTTP requests now resolve token type before execution, refreshing expired OAuth tokens as needed and persisting the new token. This ensures valid authentication for all requests. (`FanMakerSDKHttp.kt`, `FanMakerSDKHttpRequest.kt`) [[1]](diffhunk://#diff-fe58ae216ab2f0da95293ef5b1da484a1c27944e9588a0817897528f17f418adR80-R113) [[2]](diffhunk://#diff-1c60c4e36656c255717340cad338bdd7d975c5fb68b22ed7e531a3f3d9146aa1R161-R170)
* Updated header logic: Requests now set headers based on token type (API token vs OAuth token), avoiding legacy header confusion and ensuring proper authorization. (`FanMakerSDKHttpRequest.kt`, `FanMakerSDK.kt`) [[1]](diffhunk://#diff-613380a0e4481c63187709e39c36897366f4dc16610247353b954df97b1cd0d7L25-R47) [[2]](diffhunk://#diff-1c60c4e36656c255717340cad338bdd7d975c5fb68b22ed7e531a3f3d9146aa1L201-R218)
* Refactored HTTP request methods (`get`, `post`) to use the new token resolver, ensuring consistent authentication flow. (`FanMakerSDKHttp.kt`) [[1]](diffhunk://#diff-fe58ae216ab2f0da95293ef5b1da484a1c27944e9588a0817897528f17f418adL19-R21) [[2]](diffhunk://#diff-fe58ae216ab2f0da95293ef5b1da484a1c27944e9588a0817897528f17f418adL46-R54)

SDK Version & Theme:

* Bumped SDK version from `3.2.0` to `4.0.0` in both build configuration and code, reflecting major changes. (`build.gradle`, `FanMakerSDK.kt`) [[1]](diffhunk://#diff-1f853a5f09947a0f9f15e2921a2946e5154e52521c51af15ac6f6086248bee26L80-R80) [[2]](diffhunk://#diff-1c60c4e36656c255717340cad338bdd7d975c5fb68b22ed7e531a3f3d9146aa1L70-R70)
* Changed default loading screen theme to dark and added theme info to request headers. (`FanMakerSDK.kt`) [[1]](diffhunk://#diff-1c60c4e36656c255717340cad338bdd7d975c5fb68b22ed7e531a3f3d9146aa1L81-R81) [[2]](diffhunk://#diff-1c60c4e36656c255717340cad338bdd7d975c5fb68b22ed7e531a3f3d9146aa1R188)

Location & Auto Check-in:

* Improved auto check-in logic: Token is now read inside the location callback to ensure the latest value, and logging added for success/failure. (`FanMakerSDK.kt`)

These changes collectively enhance security, reliability, and user experience in the FanMaker SDK.