### PR TITLE
update readme for more accurate reflection of current SDK state

### DIFF
--- a/FanMaker/src/main/AndroidManifest.xml
+++ b/FanMaker/src/main/AndroidManifest.xml
@@ -2,16 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-feature android:name="android.hardware.camera.any" />
+    <uses-feature android:name="android.hardware.camera.any" android:required="false" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
-    <uses-permission android:name="android.permission-group.STORAGE" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.front" android:required="false" />
     <application>

--- a/FanMaker/src/main/java/com/fanmaker/sdk/FanMakerSDKWebInterface.kt
+++ b/FanMaker/src/main/java/com/fanmaker/sdk/FanMakerSDKWebInterface.kt
@@ -274,6 +274,37 @@ class FanMakerSDKWebInterface(
                     }
                 }
             }
+            "bluetoothEnabled" -> {
+                val status = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    val scanStatus = ContextCompat.checkSelfPermission(mContext, Manifest.permission.BLUETOOTH_SCAN)
+                    val connectStatus = ContextCompat.checkSelfPermission(mContext, Manifest.permission.BLUETOOTH_CONNECT)
+                    when {
+                        scanStatus == PackageManager.PERMISSION_GRANTED && connectStatus == PackageManager.PERMISSION_GRANTED -> "Granted"
+                        scanStatus == PackageManager.PERMISSION_GRANTED -> "Scan Only"
+                        connectStatus == PackageManager.PERMISSION_GRANTED -> "Connect Only"
+                        else -> "Denied"
+                    }
+                } else {
+                    "Granted"
+                }
+
+                val escapedValue = status.replace("\"", "\\\"")
+                val jsString = "FanmakerSDKCallback(\"{ \\\"value\\\": \\\"$escapedValue\\\" }\")"
+                (mContext as? android.app.Activity)?.runOnUiThread {
+                    (mContext as? android.app.Activity)?.findViewById<android.webkit.WebView>(R.id.fanmaker_sdk_webview)?.let { webView ->
+                        webView.evaluateJavascript("""
+                            if (typeof FanmakerSDKCallback === 'undefined') {
+                                window.FanmakerSDKCallback = function(data) {
+                                    window.dispatchEvent(new CustomEvent('fanmakerSDKCallback', {
+                                        detail: data
+                                    }));
+                                };
+                            }
+                            $jsString
+                        """.trimIndent(), null)
+                    }
+                }
+            }
             "locationEnabled" -> {
                 val result = jsonValueForKey("locationEnabled")
                 (mContext as? android.app.Activity)?.runOnUiThread {

--- a/README.md
+++ b/README.md
@@ -770,6 +770,10 @@ In order for Beacons Tracking to work, you need to add the following permissions
 
 > **Android 12+ Bluetooth**: `BLUETOOTH_SCAN` and `BLUETOOTH_CONNECT` are runtime permissions on Android 12 (API 31) and above. You must request both from the user at runtime in addition to declaring them in the manifest. On Android 11 and below, the legacy `BLUETOOTH` and `BLUETOOTH_ADMIN` permissions required for beacon scanning are automatically included via the altbeacon library's own manifest — no additional declarations needed for those older API levels.
 
+> **Do not use `neverForLocation`**: Do not add `android:usesPermissionFlags="neverForLocation"` to `BLUETOOTH_SCAN`. Although this flag appears to reduce permission scope, it causes Android to block iBeacon advertisement packets entirely, which breaks beacon detection.
+
+> **Background scanning on Android 8+ (API 26+)**: The SDK disables altbeacon's scheduled scan jobs (`setEnableScheduledScanJobs(false)`). On Android 8 and above, this means the OS may aggressively restrict background beacon scanning unless your app runs the altbeacon library in foreground service mode. If your integration requires reliable scanning while the app is not in the foreground, refer to the [altbeacon foreground service documentation](https://altbeacon.github.io/android-beacon-library/foreground-service.html) for setup instructions. This is a host app responsibility — the SDK does not configure the foreground service for you.
+
 ### [Reward Usage of Host App](https://blog.fanmaker.com/sdk-2-0-background-check-ins-app-rewards-and-support-for-multiple-programs/)
 
 By setting up a lifecycle observer on each instance of the FanMakerSDK, you can capture this highly useful data or award points for each day the fan uses the your host application.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The items below are **required for certification**.
 - [ ] **Background GPS permissions**
   - [Implemented](https://github.com/FanMaker/Turdroidken?tab=readme-ov-file#location-tracking-permissions)
   - Functioning as expected
-- [ ] **Background Bluetooth permissions**
-  - [Implemented](https://github.com/FanMaker/Turdroidken?tab=readme-ov-file#beacons-tracking-permissions)
+- [ ] **Background Bluetooth permissions** *(required only if using bluetooth beacons)*
+  - [Implemented](https://github.com/FanMaker/Turdroidken?tab=readme-ov-file#beacons-tracking-permissions) (`BLUETOOTH_SCAN` + `BLUETOOTH_CONNECT` on Android 12+)
   - Functioning as expected
 - [ ] **Push notification token**
   - Token for each user is passed to Fanmaker
@@ -119,36 +119,48 @@ allprojects {
 - inside dependencies of the build.gradle of app module, use the following code
 ```markdown
 dependencies {
-    implementation 'com.android.volley:volley:1.2.0'
-    implementation 'com.fanmaker.sdk:fanmaker:2.0.0'
+    implementation 'com.fanmaker.sdk:fanmaker:4.0.1'
 	...
 }
 ```
-- inside dependencies of the build.gradle of app module, make sure that you set the `compleSdkVersion` and `targetSdkVersion` to 33
+> **Note**: Volley is bundled as a transitive dependency of the SDK — you do not need to add it separately.
+
+- inside the build.gradle of your app module, make sure you set the `compileSdk`, `targetSdk`, and `minSdk` values:
 ```markdown
   android {
-    compileSdkVersion 33
+    compileSdk 35
     ...
 
     defaultConfig {
       ...
-      targetSdkVersion 33
+      minSdk 24
+      targetSdk 35
       ...
     }
   }
 ```
 
 ### Step 4 : Add the following permissions to the AndroidManifest.xml
-- Add the following code to the **AndroidManifext.xml** directly after the `<manifest ...>` tag.
-- These allow access to the camera and image gallery for user to upload profile pictures and engage with CrowdCameo.
+- Add the following code to the **AndroidManifest.xml** directly after the `<manifest ...>` tag.
+- These allow access to the camera and image gallery for users to upload profile pictures and engage with CrowdCameo.
 
 ```markdown
 <uses-permission android:name="android.permission.CAMERA" />
-<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+<!-- Legacy storage access for Android 9 and below -->
+<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
+
+<!-- Modern photo picker for Android 13+ (API 33+) -->
+<uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+
 <uses-feature android:name="android.hardware.camera" android:required="false" />
 <uses-feature android:name="android.hardware.camera.front" android:required="false" />
 ```
+
+> **Note on storage permissions**: Android 10 (API 29) introduced scoped storage. The `maxSdkVersion` attributes above ensure legacy storage permissions are only applied on older OS versions. On Android 13+ (API 33+), `READ_MEDIA_VISUAL_USER_SELECTED` enables the modern photo picker instead. The SDK handles both paths automatically.
+
+> **Note on FileProvider**: The SDK includes its own `FileProvider` for securely sharing captured photos. You do **not** need to add a FileProvider to your own manifest. If your app already declares a FileProvider, ensure the authorities do not conflict — the SDK uses `${applicationId}.fanmaker.sdk.fileprovider`.
 
 NOTE: if you are targeting SDK Version 31 or Higher, you need to make sure any activity that includes an `intent-filter` has `android:exported="true|false"` like so:
 ``` markdown
@@ -629,11 +641,13 @@ fanMakerSDK?.enableLocationTracking()
 ```
 
 ### Location Tracking Permissions
-In order for Location Tracking to work, you need to add the following permissions to your Manifest, as well as asking users for them in running time:
+In order for Location Tracking to work, you need to add the following permissions to your Manifest, as well as requesting them at runtime:
 ```
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 ```
+
+These foreground location permissions are sufficient for Auto Checkin — the GPS ping fires when the app resumes to the foreground (`onResume`), so background location access is not required for this feature. `ACCESS_BACKGROUND_LOCATION` is only needed if you are using [Beacons Tracking](https://github.com/FanMaker/Turdroidken?tab=readme-ov-file#beacons-tracking-permissions).
 
 ### Auto Checkin
 The FanMakerSDK can auto checkin users to events without them opening the FanMakerSDK itself. Once the user has successfully logged into the FanMakerSDK and granted location permissions, on subsequent opens of your application, the FanMakerSDK will automatically attempt to automatically checkin the user to events within range. Be sure to enable location tracking for the feature to be enabled on every instance of the FanMakerSDK you would like to use. You must also add a lifecycle observer to each SDK instance you'd like to have Auto Checkin and App open/resume enabled for using the `lifecycle.addObserver` method:
@@ -738,14 +752,23 @@ class BeaconEventHandler : FanMakerSDKBeaconEventHandler {
 
 ### Beacons Tracking Permissions
 
-In order for Beacons Tracking to work, you need to add the following permissions to your Manifest, as well as asking users for them in running time:
+> **Important**: Beacon tracking is an **optional feature**. Only add these permissions if your integration uses `FanMakerSDKBeaconManager`. Declaring permissions your app does not use is a violation of [Google Play's permissions policy](https://support.google.com/googleplay/android-developer/answer/9214102) and may result in rejection.
+
+In order for Beacons Tracking to work, you need to add the following permissions to your Manifest, as well as requesting them at runtime:
 
 ```
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+
+<!-- Bluetooth permissions required for beacon scanning on Android 12+ (API 31+) -->
 <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 ```
+
+> **Google Play — Background Location**: Apps that declare `ACCESS_BACKGROUND_LOCATION` are subject to an additional review in the Google Play Console. You must complete the **Background location access** declaration form in your app's Play Console and provide a justification for why background location is needed. Approval is not automatic. See [Google's guidance on background location](https://support.google.com/googleplay/android-developer/answer/9799150).
+
+> **Android 12+ Bluetooth**: `BLUETOOTH_SCAN` and `BLUETOOTH_CONNECT` are runtime permissions on Android 12 (API 31) and above. You must request both from the user at runtime in addition to declaring them in the manifest. On Android 11 and below, the legacy `BLUETOOTH` and `BLUETOOTH_ADMIN` permissions required for beacon scanning are automatically included via the altbeacon library's own manifest — no additional declarations needed for those older API levels.
 
 ### [Reward Usage of Host App](https://blog.fanmaker.com/sdk-2-0-background-check-ins-app-rewards-and-support-for-multiple-programs/)
 


### PR DESCRIPTION
This pull request updates the Android SDK integration and documentation to improve clarity around permissions, update dependencies, and add support for Bluetooth permissions on Android 12+. The changes ensure that only necessary permissions are requested, clarify Play Store requirements, and enhance the SDK's Bluetooth permission handling.

**Documentation and Manifest Updates:**

- **Permissions and Manifest Guidance:**
  - Updated `AndroidManifest.xml` to use `maxSdkVersion` for storage permissions, set camera features as optional, and removed unused permissions for a cleaner manifest.
  - Expanded README instructions to clarify which permissions are required for specific features (location, storage, Bluetooth), when to use them, and how to comply with Google Play policies. Added detailed notes about background location and Bluetooth permissions, including Play Store review requirements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L122-R164) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L632-R651) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L741-R772) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R24)

- **Dependency and SDK Version Updates:**
  - Updated the SDK dependency to version `4.0.1`, increased `compileSdk` and `targetSdk` to 35, and clarified that Volley is now a transitive dependency.

**SDK Feature Enhancements:**

- **Bluetooth Permissions Handling:**
  - Added a new `"bluetoothEnabled"` handler to `FanMakerSDKWebInterface.kt` to check runtime Bluetooth permission status (`BLUETOOTH_SCAN` and `BLUETOOTH_CONNECT`) on Android 12+ and return the result to the web interface.

**Summary of Most Important Changes**

**Manifest and Permissions:**
- Cleaned up `AndroidManifest.xml` by making camera features optional, limiting storage permissions to older OS versions, and removing unused permissions for better Play Store compliance.

**Documentation Improvements:**
- Clarified in the README which permissions are required for location tracking and beacon tracking, including Play Store policy notes and runtime permission requirements on Android 12+. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L632-R651) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L741-R772) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R24)
- Added detailed notes on storage permissions, modern photo picker, and FileProvider usage to guide developers integrating the SDK.

**SDK and Dependency Updates:**
- Updated SDK dependency to `4.0.1` and increased `compileSdk`/`targetSdk` to 35, with clarification about transitive dependencies.

**Bluetooth Feature Support:**
- Implemented runtime Bluetooth permission checks in `FanMakerSDKWebInterface.kt` to support Android 12+ requirements for beacon tracking.